### PR TITLE
Update "mu-plugin and watcher script" link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ There is a change to `WP_Upgrader::install_package()` that can't be implemented 
 
 ### VirtualBox
 
-If you are running a virtualized server and using VirtualBox your hosting environment will need to add a [mu-plugin and watcher script](https://gist.github.com/costdev/502a2ca52a440e5775e2db970227b9b3) to overcome VirtualBox's rename() issues. There are some known issues where rename() in VirtualBox can fail on shared folders
+If you are running a virtualized server and using VirtualBox your hosting environment will need to add a [mu-plugin and watcher script](https://github.com/costdev/wp-virtualbox-testing) to overcome VirtualBox's rename() issues. There are some known issues where rename() in VirtualBox can fail on shared folders
 without reporting an error properly.
 
 More details:


### PR DESCRIPTION
Change the "mu-plugin and watcher script" link to the WP VirtualBox Testing repo. This is an updated solution with detailed setup instructions.